### PR TITLE
Fix: No write permissions in $VIMRUNTIME

### DIFF
--- a/plugin/gsession.vim
+++ b/plugin/gsession.vim
@@ -37,8 +37,8 @@ fun! s:session_dir(...)
 
   if exists('g:session_dir')
     let sesdir = expand(g:session_dir)
-  elseif has('win32')
-    let sesdir = expand('$VIMRUNTIME\session')
+  elseif has('win32') || has('win64')
+    let sesdir = expand('$HOME\vimfiles\session')
   else
     let sesdir = expand('$HOME/.vim/session')
   endif


### PR DESCRIPTION
$VIMRUNTIME is the installation directory. There is a big chance, that the user has no privileges to write to $VIMRUNTIME\session on modern Windows systems. Use $HOME\vimfiles\session instead.
