### PR TITLE
Workaround for Vim `g:complete_names` function name error

### DIFF
--- a/plugin/gsession.vim
+++ b/plugin/gsession.vim
@@ -138,7 +138,7 @@ fun! s:warn(msg)
 endf
 
 " TODO: don't pollute "g:" scope.
-fun! g:complete_names(arglead, cmdline, pos)
+fun! g:Complete_names(arglead, cmdline, pos)
   let items = s:session_names(s:completing_global)
   return filter(items, "v:val =~ '^' . a:arglead")
 endf
@@ -149,7 +149,7 @@ fun! s:input_session_name(global)
   let name = input(
         \   "Session name: ",
         \   strlen('v:this_session') ? s:session_name(v:this_session) : '',
-        \   'customlist,g:complete_names'
+        \   'customlist,g:Complete_names'
         \ )
   call inputrestore()
 


### PR DESCRIPTION
Vim Patch 7.4.264 makes `g:complete_names` function name invalid.

```
E128: Function name must start with a capital or "s:": g:complete_names(arglead, cmdline, pos)
```

Solution: rename it to `g:Complete_names`.
